### PR TITLE
Take keymaterial input on a newline instead of on EOF.

### DIFF
--- a/keys
+++ b/keys
@@ -105,7 +105,8 @@ if ( $operation eq 'list' ) {
     # this seems to be unavoidable though; gitolite doesn't seem to be calling us in a way that passes down the isatty() flag.
     print STDERR "please supply the new key on STDIN (e.g. cat you.pub | ssh gitolite\@git.example.com keys add \@laptop).\n";
 
-    kf_add( $user, $keyid, safe_stdin() );
+    my $keymaterial = <STDIN>;
+    kf_add( $user, $keyid, $keymaterial );
 } elsif ( $operation eq 'del' ) {
     if ( $is_admin ) {
         die "del requires a key name (\"user\" or \"user\@device\" or \"\@device\").\n" unless ($user or $keyid); #XXX sketchy
@@ -138,16 +139,6 @@ sub fingerprint {
     # Do not print the output of $output to an untrusted destination.
     die "does not seem to be a valid pubkey\n" unless $fp;
     return $fp;
-}
-
-sub safe_stdin {
-    # read one line from STDIN
-    my $data;
-    my $ret = read STDIN, $data, 4096;
-    # current pubkeys are approx 400 bytes so we go a little overboard
-    die "could not read pubkey data" . ( defined($ret) ? "" : ": $!" ) . "\n" unless $ret;
-    die "pubkey data seems to have more than one line\n" if $data =~ /\n./;
-    return $data;
 }
 
 sub hushed_git {


### PR DESCRIPTION
Fixes https://github.com/kousu/gitolite-mods/issues/10

Taking keymaterial on EOF is bad UX: these days few people are aware
of what EOF is, and expect programs to react once they are given enough
input. And there's no reason keys can't react once it has a full line
or keymaterial, it should know. And people are more trained to press enter
to, well, enter input than to press Ctrl-D, which is nowadays obscure. (

I took safe_stdin from sskm (https://github.com/sitaramc/gitolite/blob/828152dc7f3ad421ff1eb50aeb982be664c95039/src/commands/sskm#L146-L154)
which looks like it was meant to read a limited number of characters.
I wonder if, at the time it was written, it also only read one line.
Perhaps perl itself has changed since that code was written, to make
the behaviour of read() more consistent.